### PR TITLE
Show contribution

### DIFF
--- a/mkdocs_git_authors_plugin/plugin.py
+++ b/mkdocs_git_authors_plugin/plugin.py
@@ -10,72 +10,71 @@ class GitAuthorsPlugin(BasePlugin):
 
     def __init__(self):
         self.util = Util()
-   
-        
+
     def on_page_markdown(self, markdown, page, config, files):
         """
         Replace jinja tag {{ git_authors_summary }} in markdown.
-        
-        The page_markdown event is called after the page's markdown is loaded 
-        from file and can be used to alter the Markdown source text. 
-        The meta- data has been stripped off and is available as page.meta 
+
+        The page_markdown event is called after the page's markdown is loaded
+        from file and can be used to alter the Markdown source text.
+        The meta- data has been stripped off and is available as page.meta
         at this point.
-        
+
         https://www.mkdocs.org/user-guide/plugins/#on_page_markdown
-        
+
         Args:
             markdown (str): Markdown source text of page as string
             page: mkdocs.nav.Page instance
             config: global configuration object
             site_navigation: global navigation object
-            
+
         Returns:
             str: Markdown source text of page as string
         """
-        
+
         pattern = r"\{\{\s*git_authors_summary\s*\}\}"
-        
+
         if not re.search(pattern, markdown, flags=re.IGNORECASE):
            return markdown
-        
+
         authors = self.util.get_authors(
             path = page.file.abs_src_path,
             type = self.config['type']
         )
-        authors_summary = self.util.summarize(authors) 
-        
+        authors_summary = self.util.summarize(authors)
+
         return re.sub(pattern,
                       authors_summary,
                       markdown,
                       flags=re.IGNORECASE)
-        
+
     def on_page_context(self, context, page, **kwargs):
         """
-        Add 'git_authors' and 'git_authors_summary' variables 
+        Add 'git_authors' and 'git_authors_summary' variables
         to template context.
-        
-        The page_context event is called after the context for a page 
-        is created and can be used to alter the context for that 
-        specific page only. 
-        
+
+        The page_context event is called after the context for a page
+        is created and can be used to alter the context for that
+        specific page only.
+
         Note this is called *after* on_page_markdown()
-        
+
         Args:
             context (dict): template context variables
             page (class): mkdocs.nav.Page instance
-        
+
         Returns:
             dict: template context variables
         """
-        
-         
+
+
         authors = self.util.get_authors(
             path = page.file.abs_src_path,
             type = self.config['type']
         )
-        authors_summary = self.util.summarize(authors) 
-        
+        authors_summary = self.util.summarize(authors)
+
         context['git_authors'] = authors
         context['git_authors_summary'] = authors_summary
-        
+
         return context

--- a/mkdocs_git_authors_plugin/util.py
+++ b/mkdocs_git_authors_plugin/util.py
@@ -40,24 +40,26 @@ class Util:
 
             authors = {}
             for commit, lines in blame:
-                key = commit.author.email
+                name = commit.author.name
+                email = commit.author.email
 
                 # Update existing author
-                if authors.get(key):
-                    authors[key]['lines'] = authors[key]['lines'] + len(lines)
-                    current_dt = authors.get(key,{}).get('last_datetime')
+                if authors.get(name):
+                    author = authors[name]
+                    author['lines'] = author['lines'] + len(lines)
+                    current_dt = author.get('last_datetime')
                     if commit.committed_datetime > current_dt:
-                        authors[key]['last_datetime'] = commit.committed_datetime
+                        author['last_datetime'] = commit.committed_datetime
                 # Add new author
                 else:
-                    authors[key] = {
-                        'name' : commit.author.name,
-                        'email' : key,
+                    authors[name] = {
+                        'name' : name,
+                        'email' : email,
                         'last_datetime' : commit.committed_datetime,
                         'lines' : len(lines)
                     }
 
-            authors = [authors[key] for key in authors]
+            authors = [authors[name] for name in authors]
             authors = sorted(authors, key = lambda i: i['name'])
 
             total_lines = sum([x.get('lines') for x in authors])
@@ -91,6 +93,19 @@ class Util:
             str: HTML text with authors
         """
 
-        authors_summary = ["<a href='mailto:%s'>%s</a>" % (x['email'] ,x['name']) for x in authors]
+        authors_summary = []
+        for author in authors:
+            contribution = (
+                ' (%s)' % author['contribution']
+                if len(authors) > 1
+                else ''
+            )
+            authors_summary.append(
+                "<a href='mailto:%s'>%s</a>%s" % (
+                    author['email'],
+                    author['name'],
+                    contribution
+                )
+            )
         authors_summary = ', '.join(authors_summary)
-        return "<span class='git-authors'>" + authors_summary + "</span>"
+        return "<span class='git-authors'>%s</span>" % authors_summary

--- a/mkdocs_git_authors_plugin/util.py
+++ b/mkdocs_git_authors_plugin/util.py
@@ -4,7 +4,7 @@ from pathlib import Path
 class Util:
 
     def __init__(self, path = "."):
-        self.repo = Repo(path)
+        self.repo = Repo(path, search_parent_directories=True)
         # Cache authors entries by path
         self._authors = {}
 

--- a/mkdocs_git_authors_plugin/util.py
+++ b/mkdocs_git_authors_plugin/util.py
@@ -17,7 +17,7 @@ class Util:
             type (str, optional): How to determine authors. Defaults to 'en'.
 
         Returns:
-            list: unique authors
+            list (str): unique authors, or empty list
         """
 
         authors = self._authors.get(path, [])

--- a/mkdocs_git_authors_plugin/util.py
+++ b/mkdocs_git_authors_plugin/util.py
@@ -15,18 +15,18 @@ class Util:
             type (str, optional): How to determine authors. Defaults to 'en'.
 
         Returns:
-            str: unique authors
+            list (str): unique authors, or empty list
         """
 
         try:
             blame = self.repo.blame('HEAD',path)
         except:
             print("WARNING - %s has no commits" % path)
-            return ""
+            return []
 
         if len(Path(path).read_text()) == 0:
             print("WARNING - %s has no lines" % path)
-            return ""
+            return []
 
         authors = {}
         for commit, lines in blame:

--- a/mkdocs_git_authors_plugin/util.py
+++ b/mkdocs_git_authors_plugin/util.py
@@ -9,35 +9,35 @@ class Util:
     def get_authors(self, path: str, type: str = 'authors'):
         """
         Determine git authors for a given file
-        
+
         Args:
             path (str): Location of a file that is part of a GIT repository
             type (str, optional): How to determine authors. Defaults to 'en'.
-        
+
         Returns:
             str: unique authors
         """
-        
+
         try:
             blame = self.repo.blame('HEAD',path)
         except:
             print("WARNING - %s has no commits" % path)
             return ""
-       
+
         if len(Path(path).read_text()) == 0:
             print("WARNING - %s has no lines" % path)
             return ""
-             
+
         authors = {}
         for commit, lines in blame:
             key = commit.author.email
-            
+
             # Update existing author
             if authors.get(key):
                 authors[key]['lines'] = authors[key]['lines'] + len(lines)
                 current_dt = authors.get(key,{}).get('last_datetime')
                 if commit.committed_datetime > current_dt:
-                    authors[key]['last_datetime'] = commit.committed_datetime 
+                    authors[key]['last_datetime'] = commit.committed_datetime
             # Add new author
             else:
                 authors[key] = {
@@ -46,20 +46,20 @@ class Util:
                     'last_datetime' : commit.committed_datetime,
                     'lines' : len(lines)
                 }
-        
+
         authors = [authors[key] for key in authors]
         authors = sorted(authors, key = lambda i: i['name'])
-        
+
         total_lines = sum([x.get('lines') for x in authors])
         for author in authors:
             author['contribution'] = self._format_perc(author['lines'] / total_lines)
-        
+
         return authors
-    
+
     @staticmethod
     def _format_perc(n, decimals = 2):
         """Formats a decimal as a percentage
-        
+
         Args:
             n (float): [description]
         """
@@ -71,14 +71,14 @@ class Util:
     def summarize(authors):
         """
         Summarized list of authors to a HTML string
-        
+
         Args:
             authors (list): List with author dicts
-            
+
         Returns:
             str: HTML text with authors
         """
-        
+
         authors_summary = ["<a href='mailto:%s'>%s</a>" % (x['email'] ,x['name']) for x in authors]
         authors_summary = ', '.join(authors_summary)
-        return "<span class='git-authors'>" + authors_summary + "</span>" 
+        return "<span class='git-authors'>" + authors_summary + "</span>"

--- a/mkdocs_git_authors_plugin/util.py
+++ b/mkdocs_git_authors_plugin/util.py
@@ -5,6 +5,8 @@ class Util:
 
     def __init__(self, path = "."):
         self.repo = Repo(path)
+        # Cache authors entries by path
+        self._authors = {}
 
     def get_authors(self, path: str, type: str = 'authors'):
         """
@@ -15,44 +17,54 @@ class Util:
             type (str, optional): How to determine authors. Defaults to 'en'.
 
         Returns:
-            list (str): unique authors, or empty list
+            list: unique authors
         """
 
-        try:
-            blame = self.repo.blame('HEAD',path)
-        except:
-            print("WARNING - %s has no commits" % path)
+        authors = self._authors.get(path, [])
+
+        if authors == False:
             return []
 
-        if len(Path(path).read_text()) == 0:
-            print("WARNING - %s has no lines" % path)
-            return []
+        if not authors:
+            try:
+                blame = self.repo.blame('HEAD',path)
+            except:
+                print("WARNING - %s has no commits" % path)
+                self._authors[path] = False
+                return []
 
-        authors = {}
-        for commit, lines in blame:
-            key = commit.author.email
+            if len(Path(path).read_text()) == 0:
+                print("WARNING - %s has no lines" % path)
+                self._authors[path] = False
+                return []
 
-            # Update existing author
-            if authors.get(key):
-                authors[key]['lines'] = authors[key]['lines'] + len(lines)
-                current_dt = authors.get(key,{}).get('last_datetime')
-                if commit.committed_datetime > current_dt:
-                    authors[key]['last_datetime'] = commit.committed_datetime
-            # Add new author
-            else:
-                authors[key] = {
-                    'name' : commit.author.name,
-                    'email' : key,
-                    'last_datetime' : commit.committed_datetime,
-                    'lines' : len(lines)
-                }
+            authors = {}
+            for commit, lines in blame:
+                key = commit.author.email
 
-        authors = [authors[key] for key in authors]
-        authors = sorted(authors, key = lambda i: i['name'])
+                # Update existing author
+                if authors.get(key):
+                    authors[key]['lines'] = authors[key]['lines'] + len(lines)
+                    current_dt = authors.get(key,{}).get('last_datetime')
+                    if commit.committed_datetime > current_dt:
+                        authors[key]['last_datetime'] = commit.committed_datetime
+                # Add new author
+                else:
+                    authors[key] = {
+                        'name' : commit.author.name,
+                        'email' : key,
+                        'last_datetime' : commit.committed_datetime,
+                        'lines' : len(lines)
+                    }
 
-        total_lines = sum([x.get('lines') for x in authors])
-        for author in authors:
-            author['contribution'] = self._format_perc(author['lines'] / total_lines)
+            authors = [authors[key] for key in authors]
+            authors = sorted(authors, key = lambda i: i['name'])
+
+            total_lines = sum([x.get('lines') for x in authors])
+            for author in authors:
+                author['contribution'] = self._format_perc(author['lines'] / total_lines)
+
+            self._authors[path] = authors
 
         return authors
 


### PR DESCRIPTION
Merge authors and show contribution

Sometimes authors commit with different email addresses or
change them over time. This commit changes the key in the authors
dictionary to be commit.author.name to merge such "virtual committers"
(if they have differing user names there's not much we can do about it).

(This is again on top of #2 and #3, although it is conceptually independent from them)