### PR TITLE
Instructions to aggregate authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,21 @@ An example of how to use in your templates:
 ```
 
 Alternatively, you could use the simple preformatted ``{{ git_authors_summary }}`` to insert a summary of the authors.
+
+### Aggregating Authors
+
+In some repositories authors may have committed with differing name/email combinations.
+In order to prevent the output being split it is possible to aggregate authors on
+arbitrary elements by providing a file `.mailmap` in the repository's root directory.
+This is a feature of Git itself. The following example will aggregate the contributions
+of Jane Doe committed under two email addresses:
+
+```
+# .mailmap
+Jane Doe <jane.doe@company.com> <jane.doe@private-email.com>
+```
+
+This will map commits made with the `private-email.com` to the company address. For more details
+and further options (e.g. mapping between different names or misspellings etc. see the
+[git-blame documentation](https://git-scm.com/docs/git-blame#_mapping_authors).
+


### PR DESCRIPTION
Git itself offers a tool to aggregate authors in a much more versatile manner
than what we could or should provide in secondary code.

So this documentation hint more than resolves my stated needs for aggregation
and is much better than any implementation I could have done.