### PR TITLE
README.md: pip3 reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Other MkDocs plugins that use information from git:
 
 ## Setup
 
-Install the plugin using pip:
+Install the plugin using pip3:
 
 ```bash
-pip install mkdocs-git-authors-plugin
+pip3 install mkdocs-git-authors-plugin
 ```
 
 Next, add the following lines to your `mkdocs.yml`:


### PR DESCRIPTION
If the plugin requires Python3 `pip3` should be listed as installation tool.

=> Theses issues have taken me very long to get familiar with ...