### PR TITLE
Fix readme #35

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -518,3 +518,7 @@ healthchecksdb
 MigrationBackup/
 # End of https://www.gitignore.io/api/r,macos,python,pycharm,windows,visualstudio,jupyternotebooks
 .vscode/
+
+# VS Code custom
+.venv/
+tests/basic_setup/site

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Which renders as:
 
 As an example, if you use [mkdocs-material](https://github.com/squidfunk/mkdocs-material) you can implement git-authors by [overriding a template block](https://squidfunk.github.io/mkdocs-material/customization/#overriding-template-blocks):
 
-1) Create a new file `base.html` in `docs/assets/theme`:
+1) Create a new file `main.html` in `docs/theme`:
 
 ```html
 {% extends "base.html" %}
@@ -87,7 +87,7 @@ As an example, if you use [mkdocs-material](https://github.com/squidfunk/mkdocs-
 ```yml
 theme:
     name: material
-    custom_dir: docs/assets/theme/
+    custom_dir: docs/theme/
 ```
 
 ### In theme templates

--- a/tests/basic_setup/docs/index.md
+++ b/tests/basic_setup/docs/index.md
@@ -1,3 +1,7 @@
-# Test page
+# Test with plugin tags
 
-Markdown tag: {{ git_authors_summary }}
+Page authors: {{ git_page_authors }}
+
+----
+
+Site authors: {{ git_site_authors }}

--- a/tests/basic_setup/docs/page_with_tag.md
+++ b/tests/basic_setup/docs/page_with_tag.md
@@ -1,0 +1,7 @@
+# Page with plugin tag
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+## Content
+
+Markdown tag: {{ git_authors_summary }}

--- a/tests/basic_setup/docs/page_without_tag.md
+++ b/tests/basic_setup/docs/page_without_tag.md
@@ -1,3 +1,3 @@
-# test page
+# Test page without tag
 
 this page has no git authors tag

--- a/tests/basic_setup/docs/second_page.md
+++ b/tests/basic_setup/docs/second_page.md
@@ -1,3 +1,0 @@
-# Second Test page
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/basic_setup/docs/theme/main.html
+++ b/tests/basic_setup/docs/theme/main.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block disqus %}
+<div class="md-source-date">
+  <small>
+    Authors: {{ git_authors_summary }}
+    <br>
+    Old tag: {{ git_page_authors }}
+  </small>
+</div>
+{% include "partials/integrations/disqus.html" %}
+{% endblock %}

--- a/tests/basic_setup/mkdocs_complete_material.yml
+++ b/tests/basic_setup/mkdocs_complete_material.yml
@@ -1,0 +1,15 @@
+site_name: test gitauthors_plugin with material theme and git-revision-date
+use_directory_urls: true
+
+theme:
+    name: 'material'
+    custom_dir: 'docs/theme'
+    language: nl
+
+plugins:
+    - search
+    - git-authors:
+        count_empty_lines: false
+        show_contribution: true
+        show_line_count: true
+    - git-revision-date-localized

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,6 +1,13 @@
+# testing
 pytest
 pytest-cov
 codecov
+
+# sub-libs
 click
 GitPython
+
+# mkdocs
 mkdocs
+mkdocs-git-revision-date-localized-plugin
+mkdocs-material


### PR DESCRIPTION
Two minor changes in README to close #35:

- path to the template override should be `docs/them/main.html` (not `docs/assets/theme`)
- override file should be named `main.html` (not `base.html`) to avoid recursion error