### PR TITLE
Handle cases where a page has 0 line and still no git log

### DIFF
--- a/mkdocs_git_authors_plugin/git/author.py
+++ b/mkdocs_git_authors_plugin/git/author.py
@@ -1,3 +1,5 @@
+import logging
+
 from .repo import AbstractRepoObject, Repo
 from .page import Page
 from .commit import Commit
@@ -61,7 +63,17 @@ class Author(AbstractRepoObject):
         total_lines = (
             self.page(path)["page"].total_lines() if path else self.repo().total_lines()
         )
-        result = lines / total_lines
+
+        try:
+            result = lines / total_lines
+        except ZeroDivisionError as err:
+            logging.error(
+                "Calcultation of contribution for page '{}' ({}/{}) failed: {}".format(
+                    path, lines, total_lines, err
+                )
+            )
+            return float(0)
+
         if _type == float:
             return result
         else:


### PR DESCRIPTION
Close #38 

But I'm not sure if it's the good solution. I think the plugin should handle cases where a page has still no git history and maybe 0 lines.