### PR TITLE
Add fallback_to_empty option for Git-less environments

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -8,6 +8,7 @@ plugins:
         show_contribution: true
         show_line_count: true
         count_empty_lines: true
+        fallback_to_empty: false
 ```
 
 ## `show_contribution`
@@ -28,3 +29,7 @@ If this option is set to `true` (default: `false`) the number of lines per autho
 ## `count_empty_lines`
 
 If this option is set to `true` (default: `false`) empty lines will count towards an authors' contribution.
+
+## `fallback_to_empty`
+
+If this option is set to `true` (default: `false`) the plugin will work even outside of a proper Git environment, prompting a warning when it's the case, and resulting in empty author list.

--- a/mkdocs_git_authors_plugin/plugin.py
+++ b/mkdocs_git_authors_plugin/plugin.py
@@ -108,14 +108,13 @@ class GitAuthorsPlugin(BasePlugin):
         Returns:
             str: HTML text of page as string
         """
-        if self._fallback:
-            return html
 
         list_pattern = re.compile(
             r"\{\{\s*git_site_authors\s*\}\}", flags=re.IGNORECASE
         )
         if list_pattern.search(html):
             html = list_pattern.sub(
+                "" if self._fallback else
                 util.site_authors_summary(self.repo().get_authors(), self.config), html
             )
         return html
@@ -140,9 +139,6 @@ class GitAuthorsPlugin(BasePlugin):
         Returns:
             str: Markdown source text of page as string
         """
-        if self._fallback:
-            return markdown
-
         pattern_authors_summary = re.compile(
             r"\{\{\s*git_authors_summary\s*\}\}", flags=re.IGNORECASE
         )
@@ -153,6 +149,11 @@ class GitAuthorsPlugin(BasePlugin):
         if not pattern_authors_summary.search(
             markdown
         ) and not pattern_page_authors.search(markdown):
+            return markdown
+
+        if self._fallback:
+            markdown = pattern_authors_summary.sub("", markdown)
+            markdown = pattern_page_authors.sub("", markdown)
             return markdown
 
         page_obj = self.repo().page(page.file.abs_src_path)

--- a/mkdocs_git_authors_plugin/plugin.py
+++ b/mkdocs_git_authors_plugin/plugin.py
@@ -13,7 +13,7 @@ class GitAuthorsPlugin(BasePlugin):
         ("show_contribution", config_options.Type(bool, default=False)),
         ("show_line_count", config_options.Type(bool, default=False)),
         ("count_empty_lines", config_options.Type(bool, default=True)),
-        ("fallback_to_empty_authors", config_options.Type(bool, default=False))
+        ("fallback_to_empty", config_options.Type(bool, default=False))
         # ('sort_authors_by_name', config_options.Type(bool, default=True)),
         # ('sort_reverse', config_options.Type(bool, default=False))
     )
@@ -23,7 +23,10 @@ class GitAuthorsPlugin(BasePlugin):
             self._repo = Repo()
             self._fallback = False
         except GitCommandError:
-            self._fallback = True
+            if self.config["fallback_to_empty"]:
+                self._fallback = True
+            else:
+                raise
 
     def on_config(self, config, **kwargs):
         """

--- a/tests/basic_setup/mkdocs_fallback.yml
+++ b/tests/basic_setup/mkdocs_fallback.yml
@@ -1,0 +1,7 @@
+site_name: test gitauthors_plugin
+use_directory_urls: true
+
+plugins:
+    - search
+    - git-authors:
+        fallback_to_empty: true

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -127,12 +127,14 @@ def test_fallback(tmp_path):
         "tests/basic_setup/docs", str(testproject_path / "website" / "docs")
     )
     shutil.copyfile(
-        "tests/basic_setup/mkdocs_w_contribution.yml",
+        "tests/basic_setup/mkdocs_fallback.yml",
         str(testproject_path / "website" / "mkdocs.yml"),
     )
 
     cwd = os.getcwd()
     os.chdir(str(testproject_path))
+
+    print(str(testproject_path))
 
     result = build_docs_setup(
         str(testproject_path / "website/mkdocs.yml"), str(testproject_path / "site")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -124,7 +124,7 @@ def test_fallback(tmp_path):
     testproject_path = tmp_path / "testproject"
 
     shutil.copytree(
-        "tests/basic_setup/empty_site", str(testproject_path / "website" / "docs")
+        "tests/basic_setup/docs", str(testproject_path / "website" / "docs")
     )
     shutil.copyfile(
         "tests/basic_setup/mkdocs_w_contribution.yml",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -111,3 +111,34 @@ def test_building_empty_site(tmp_path):
     )
 
     os.chdir(cwd)
+
+
+def test_fallback(tmp_path):
+    """
+    Structure:
+    
+    tmp_path/testproject
+    website/
+        ├── docs/
+        └── mkdocs.yml"""
+    testproject_path = tmp_path / "testproject"
+
+    shutil.copytree(
+        "tests/basic_setup/empty_site", str(testproject_path / "website" / "docs")
+    )
+    shutil.copyfile(
+        "tests/basic_setup/mkdocs_w_contribution.yml",
+        str(testproject_path / "website" / "mkdocs.yml"),
+    )
+
+    cwd = os.getcwd()
+    os.chdir(str(testproject_path))
+
+    result = build_docs_setup(
+        str(testproject_path / "website/mkdocs.yml"), str(testproject_path / "site")
+    )
+    assert result.exit_code == 0, (
+        "'mkdocs build' command failed. Error: %s" % result.stdout
+    )
+
+    os.chdir(cwd)


### PR DESCRIPTION
With the `fallback_to_empty` option #51 is fixed.