### PR TITLE
sort the authors by contribution and eliminate low-contribution authors

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -9,6 +9,8 @@ plugins:
         show_line_count: true
         count_empty_lines: true
         fallback_to_empty: false
+        sort_authors_by: name
+        authorship_threshold_percent: 10
         exclude:
             - index.md
         enabled: true
@@ -51,6 +53,14 @@ plugins:
         - another_page.md
         - folder/*
 ```
+
+## `sort_authors_by`
+
+Defaults to `name`, can be `contribution` to sort the authors by contribution percentage without needing to show the exact percent.
+
+## `authorship_threshold_percent`
+
+Default is `0%`. This option sets the minimum contribution percentage for an author to be included in the list of authors. This can be useful when you have a large number of single line authors who contributed minor spelling fixes, and not major content. This option does not apply if there is only one author.
 
 ## `enabled`
 

--- a/mkdocs_git_authors_plugin/git/page.py
+++ b/mkdocs_git_authors_plugin/git/page.py
@@ -60,9 +60,13 @@ class Page(AbstractRepoObject):
         """
         if not self._sorted:
             repo = self.repo()
-            reverse = repo.config("show_line_count") or repo.config("show_contribution")
+            reverse = repo.config("show_line_count") or repo.config("show_contribution") or repo.config("sort_authors_by") == "contribution"
             self._authors = sorted(self._authors, key=repo._sort_key, reverse=reverse)
             self._sorted = True
+            # TODO - Remove authors with under a certain line percentage
+            author_threshold = repo.config("authorship_threshold_percent")
+            if author_threshold > 0 and len(self._authors) > 1:
+                self._authors = [a for a in self._authors if a.contribution()*100 > author_threshold]
         return self._authors
 
     def _process_git_blame(self):

--- a/mkdocs_git_authors_plugin/git/page.py
+++ b/mkdocs_git_authors_plugin/git/page.py
@@ -63,8 +63,8 @@ class Page(AbstractRepoObject):
             reverse = repo.config("show_line_count") or repo.config("show_contribution") or repo.config("sort_authors_by") == "contribution"
             self._authors = sorted(self._authors, key=repo._sort_key, reverse=reverse)
             self._sorted = True
-            # TODO - Remove authors with under a certain line percentage
             author_threshold = repo.config("authorship_threshold_percent")
+            print(f"threshold={author_threshold}", f"authors={self._authors}")
             if author_threshold > 0 and len(self._authors) > 1:
                 self._authors = [a for a in self._authors if a.contribution()*100 > author_threshold]
         return self._authors

--- a/mkdocs_git_authors_plugin/git/repo.py
+++ b/mkdocs_git_authors_plugin/git/repo.py
@@ -152,7 +152,7 @@ class Repo(object):
         Returns:
             comparison key for the sorted() function,
         """
-        if self.config("show_line_count") or self.config("show_contribution"):
+        if self.config("show_line_count") or self.config("show_contribution") or self.config("sort_authors_by") == "contribution":
             key = "contribution"
         else:
             key = "name"

--- a/mkdocs_git_authors_plugin/plugin.py
+++ b/mkdocs_git_authors_plugin/plugin.py
@@ -19,6 +19,8 @@ class GitAuthorsPlugin(BasePlugin):
         ("fallback_to_empty", config_options.Type(bool, default=False)),
         ("exclude", config_options.Type(list, default=[])),
         ("enabled", config_options.Type(bool, default=True)),
+        ("sort_authors_by", config_options.Type(str, default="name")),
+        ("authorship_threshold_percent", config_options.Type(int, default=0)),
         # ('sort_authors_by_name', config_options.Type(bool, default=True)),
         # ('sort_reverse', config_options.Type(bool, default=False))
     )

--- a/tests/basic_setup/mkdocs.yml
+++ b/tests/basic_setup/mkdocs.yml
@@ -3,4 +3,6 @@ use_directory_urls: true
 
 plugins:
     - search
-    - git-authors
+    - git-authors:
+          sort_authors_by: "contribution"
+          authorship_threshold_percent: 50

--- a/tests/basic_setup/mkdocs_w_contribution.yml
+++ b/tests/basic_setup/mkdocs_w_contribution.yml
@@ -7,3 +7,4 @@ plugins:
         count_empty_lines: false
         show_contribution: true
         show_line_count: true
+        authorship_threshold_percent: 50


### PR DESCRIPTION
1. It is helpful to eliminate authors with a very low contribution percentage.
2. It is helpful to sort authors by contribution percentage without showing the percentage

As a result, the following config options are added:
1. `sort_authors_by` - defaults to `name`, can also be `contribution`
2. `authorship_threshold_percent` - defaults to `0` for backwards compatibility. Sets the lower bound for inclusion as an author.