### PR TITLE
Add strict option

### DIFF
--- a/mkdocs_git_authors_plugin/git/page.py
+++ b/mkdocs_git_authors_plugin/git/page.py
@@ -18,7 +18,7 @@ class Page(AbstractRepoObject):
     modified by that commit.
     """
 
-    def __init__(self, repo: Repo, path: Path):
+    def __init__(self, repo: Repo, path: Path, strict: bool):
         """
         Instantiate a Page object
 
@@ -31,13 +31,21 @@ class Page(AbstractRepoObject):
         self._sorted = False
         self._total_lines = 0
         self._authors: List[dict] = list()
+        self._strict = strict
+        
         try:
             self._process_git_blame()
         except GitCommandError:
-            logger.warning(
-                "[git-authors-plugin] %s has not been committed yet. Lines are not counted"
-                % path
-            )
+            if self._strict:
+                logger.warning(
+                    "[git-authors-plugin] %s has not been committed yet. Lines are not counted"
+                    % path
+                )
+            else:
+                logger.info(
+                    "[git-authors-plugin] %s has not been committed yet. Lines are not counted"
+                    % path
+                )
 
     def add_total_lines(self, cnt: int = 1):
         """

--- a/mkdocs_git_authors_plugin/git/repo.py
+++ b/mkdocs_git_authors_plugin/git/repo.py
@@ -130,7 +130,7 @@ class Repo(object):
         if not self._pages.get(path):
             from .page import Page
 
-            self._pages[path] = Page(self, path)
+            self._pages[path] = Page(self, path, self.config("strict"))
         return self._pages[path]
 
     def set_config(self, plugin_config):

--- a/mkdocs_git_authors_plugin/plugin.py
+++ b/mkdocs_git_authors_plugin/plugin.py
@@ -23,6 +23,7 @@ class GitAuthorsPlugin(BasePlugin):
         ("enabled", config_options.Type(bool, default=True)),
         ("sort_authors_by", config_options.Type(str, default="name")),
         ("authorship_threshold_percent", config_options.Type(int, default=0)),
+        ("strict", config_options.Type(bool, default=True)),
         # ('sort_authors_by_name', config_options.Type(bool, default=True)),
         # ('sort_reverse', config_options.Type(bool, default=False))
     )

--- a/tests/basic_setup/mkdocs_complete_material_strict.yml
+++ b/tests/basic_setup/mkdocs_complete_material_strict.yml
@@ -1,0 +1,11 @@
+site_name: test gitauthors_plugin with material theme and git-authors - strict true
+use_directory_urls: true
+
+theme:
+    name: 'material'
+    language: nl
+
+plugins:
+    - search
+    - git-authors:
+        strict: true

--- a/tests/basic_setup/mkdocs_complete_material_strict_false.yml
+++ b/tests/basic_setup/mkdocs_complete_material_strict_false.yml
@@ -1,0 +1,11 @@
+site_name: test gitauthors_plugin with material theme and git-authors - strict false
+use_directory_urls: true
+
+theme:
+    name: 'material'
+    language: nl
+
+plugins:
+    - search
+    - git-authors:
+        strict: false


### PR DESCRIPTION
## Description
<!---- what does your MR do? --->
Adds support for strict config option similar to what was done for mkdocs-git-revision-date-localized-plugin. 

Apologies on not building out a complete test suite - I know enough to be dangerous. Included are two mkdocs.yml however:
- tests/basic_setup/mkdocs_complete_material_strict.yml
  - `mkdocs serve -f ./tests/basic_setup/mkdocs_complete_material_strict.yml --strict` 
  - will fail with an uncommitted file
- tests/basic_setup/mkdocs_complete_material_strict_false.yml
  - `mkdocs serve -f ./tests/basic_setup/mkdocs_complete_material_strict_false.yml --strict` 
  - will warn with INFO with an uncommitted file

## Rationale
<!---- justification for the MR --->
Currently using this plugin with Material mkdocs Insiders, namely the Blog plugin. The Blog plugin creates a number of temporary files that I'm unable to ignore as they exist outside of the docs/ folder, though I still want to use the `--strict` serve option.