### PR TITLE
Custom href option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -8,6 +8,7 @@ plugins:
         show_contribution: true
         show_line_count: true
         show_email_address: true
+        href: "mailto:{email}"
         count_empty_lines: true
         fallback_to_empty: false
         sort_authors_by: name
@@ -35,8 +36,14 @@ If this option is set to `true` (default: `false`) the number of lines per autho
 ## `show_email_address`
 
 If this option is set to `true` (default: `true`), then authors' names
-are rendered as a `mailto:` link pointing to their email address. If
+are rendered as (by default) a `mailto:{email}` link pointing to their email address. If
 set to `false`, they are shown in plain text.
+
+## `href`
+
+Given `show_email_adress` is set to `true`, you can customize the rendered link with the option `href`
+(default: `mailto:{email}`) using the f-string format (available `{email}` and `{name}`).
+This is useful to link to IM tools i.e. `href: "https://teams.microsoft.com/l/chat/0/0?users={email}"`.
 
 ## `count_empty_lines`
 

--- a/mkdocs_git_authors_plugin/plugin.py
+++ b/mkdocs_git_authors_plugin/plugin.py
@@ -17,6 +17,7 @@ class GitAuthorsPlugin(BasePlugin):
         ("show_contribution", config_options.Type(bool, default=False)),
         ("show_line_count", config_options.Type(bool, default=False)),
         ("show_email_address", config_options.Type(bool, default=True)),
+        ("href", config_options.Type(str, default='mailto:{email}')),
         ("count_empty_lines", config_options.Type(bool, default=True)),
         ("fallback_to_empty", config_options.Type(bool, default=False)),
         ("exclude", config_options.Type(list, default=[])),

--- a/mkdocs_git_authors_plugin/util.py
+++ b/mkdocs_git_authors_plugin/util.py
@@ -59,7 +59,9 @@ def page_authors_summary(page, config: dict):
             else ""
         )
         if page.repo().config("show_email_address"):
-            author_name = "<a href='mailto:%s'>%s</a>" % (author.email(), author.name())
+            href = page.repo().config("href").format(email=author.email(),
+                                                     name=author.name())
+            author_name = "<a href='%s'>%s</a>" % (href, author.name())
         else:
             author_name = author.name()
         authors_summary.append("%s%s" % (author_name, contrib))
@@ -105,7 +107,9 @@ def site_authors_summary(authors, config: dict):
         lines = ": %s lines" % author.lines() if show_line_count else ""
         author_name = ""
         if show_email_address:
-            author_name = '<a href="mailto:%s">%s</a>' % (author.email(), author.name())
+            href = config["href"].format(email=author.email(),
+                                         name=author.name())
+            author_name = '<a href="%s">%s</a>' % (href, author.name())
         else:
             author_name = author.name()
         result += """

--- a/tests/basic_setup/mkdocs_custom_href.yml
+++ b/tests/basic_setup/mkdocs_custom_href.yml
@@ -1,0 +1,7 @@
+site_name: test gitauthors_plugin
+use_directory_urls: true
+
+plugins:
+    - search
+    - git-authors:
+        href: "https://teams.microsoft.com/l/chat/0/0?users={email}"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -29,6 +29,7 @@ from contextlib import contextmanager
 
 SITES_THAT_SHOULD_SUCCEED = [
     "mkdocs.yml",
+    "mkdocs_custom_href.yml",
     "mkdocs_complete_material_disabled.yml",
     "mkdocs_complete_material.yml",
     "mkdocs_exclude.yml",
@@ -90,6 +91,27 @@ def test_basic_working(tmp_path, mkdocs_file):
     contents = index_file.read_text()
     assert re.search("<span class='git-page-authors", contents)
     assert re.search('<a href="mailto:vinktim@gmail.com">Tim Vink</a>', contents)
+
+
+def test_custom_href(tmp_path):
+    """
+    """
+    result = build_docs_setup("tests/basic_setup/mkdocs_custom_href.yml", tmp_path)
+    assert result.exit_code == 0, (
+            "'mkdocs build' command failed. Error: %s" % result.stdout
+    )
+
+    index_file = tmp_path / "index.html"
+    assert index_file.exists(), "%s does not exist" % index_file
+
+    contents = index_file.read_text()
+    assert re.search("<span class='git-page-authors", contents)
+    # Checking Page Authors
+    assert re.search((r"<p>Page authors:.*<a href='https://teams.microsoft.com/l/chat/0/0\?"
+                      "users=vinktim@gmail.com'>Tim Vink</a>.*<\/p>"), contents)
+    # Checking Site Authors
+    assert re.search(('<li><a href="https://teams.microsoft.com/l/chat/0/0\?'
+                      'users=vinktim@gmail.com">Tim Vink</a><\/li>'), contents)
 
 
 


### PR DESCRIPTION
This PR allows for a customization of the default `mailto: {email}` href. This is particularly useful to link sites with IM tools such as teams or slack
``` yaml
> cat tests/basic_setup/mkdocs_custom_href.yml
site_name: test gitauthors_plugin
use_directory_urls: true

plugins:
    - search
    - git-authors:
        href: "https://teams.microsoft.com/l/chat/0/0?users={email}"
```

![2023-05-10-19-59-51](https://github.com/timvink/mkdocs-git-authors-plugin/assets/16599907/527269cb-c7f3-4164-beaf-46a0c01bb7ce)