### PR TITLE
fix: determine contribution on page level

### DIFF
--- a/mkdocs_git_authors_plugin/git/page.py
+++ b/mkdocs_git_authors_plugin/git/page.py
@@ -82,7 +82,7 @@ class Page(AbstractRepoObject):
                 self._authors = [
                     a
                     for a in self._authors
-                    if a.contribution() * 100 > author_threshold
+                    if a.contribution(self._path) * 100 > author_threshold
                 ]
         return self._authors
 


### PR DESCRIPTION
I spotted a minor bug in determining whether an author surpasses the contribution threshold, this resolves this issue.

Bug: contribution was computed overall.

Solution: compute contribution on page level.