### PR TITLE
New config option: enabled_on_serve

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -12,9 +12,9 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
-        fetch_depth: '0'
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,7 +9,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Setup Python  
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/unittests_codecov.yml
+++ b/.github/workflows/unittests_codecov.yml
@@ -19,7 +19,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/docs/options.md
+++ b/docs/options.md
@@ -15,6 +15,7 @@ plugins:
         exclude:
             - index.md
         enabled: true
+        enabled_on_serve: true
         strict: true
 ```
 
@@ -87,6 +88,10 @@ Which enables you do disable the plugin locally using:
 export ENABLED_GIT_AUTHORS=false
 mkdocs serve
 ```
+
+## `enabled_on_serve`
+
+Default is `true`. Allows you to deactivate this plugin when `mkdocs` is called with the command `serve`. A possible use case is local development where you might want faster build times and/or do not have git available.
 
 ## `strict`
 


### PR DESCRIPTION
As mentioned in https://github.com/timvink/mkdocs-git-authors-plugin/issues/80 this PR introduces a new config option `enabled_on_serve`.  This allows you to deactivate this plugin when `mkdocs` is called with the command `serve`.

The wording/naming for this new config option is inspired by  https://github.com/squidfunk/mkdocs-material/blob/master/src/plugins/info/config.py#L31

As I struggled writing a test where the MkDocs `serve` command is involved, this PR comes without a test (for now)...

But honestly, I'm not sure if this new option is even necessary: the existing `enabled` option plus an environment variable  works just fine. 