### PR TITLE
Update options.md

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -118,10 +118,9 @@ Default is `true`. When enabled, the logs will show warnings when something is w
 - If you want to raise an error when a warning is logged, use [mkdocs strict mode](https://www.mkdocs.org/user-guide/configuration/#strict) (with `mkdocs build --strict`).
 - If you are already using [mkdocs strict mode](https://www.mkdocs.org/user-guide/configuration/#strict), but do not care about these warnings, you can set `strict: false` to ensure no errors are raised.
 
-=== ":octicons-file-code-16: mkdocs.yml"
-
-  ```yaml
-  plugins:
-    - git-authors:
-        strict: true
-  ```
+```yaml
+# mkdocs.yml
+plugins:
+  - git-authors:
+      strict: true
+```


### PR DESCRIPTION
This PR fixes the indentation of last code block about usage of `strict` option.

Additionally an old line starting a tab environment in mkdocs-material is removed. Previously it contained the filename `mkdocs.yaml` which is now included in the code block just like in all other code blocks.

![grafik](https://github.com/user-attachments/assets/92e4e772-52ec-4e0d-9fd9-0fb61f7f0d74)
