### PR TITLE
Update Gitlab Build Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This plugin needs access to the last commit that touched a specific file to be a
   <summary>Change your CI settings</summary>
   
   - github actions: set `fetch_depth` to `0` ([docs](https://github.com/actions/checkout))
-  - gitlab Runners: set `GIT_DEPTH` to `0` ([docs](https://docs.gitlab.com/ee/ci/pipelines/settings.html#limit-the-number-of-changes-fetched-during-clone))
+  - gitlab runners: set `GIT_DEPTH` to `0` ([docs](https://docs.gitlab.com/ee/ci/pipelines/settings.html#limit-the-number-of-changes-fetched-during-clone))
   - bitbucket pipelines: set `clone: depth: full` ([docs](https://support.atlassian.com/bitbucket-cloud/docs/configure-bitbucket-pipelinesyml/))
 </details>
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This plugin needs access to the last commit that touched a specific file to be a
   <summary>Change your CI settings</summary>
   
   - github actions: set `fetch_depth` to `0` ([docs](https://github.com/actions/checkout))
-  - gitlab runners: set `GIT_DEPTH` to `1000` ([docs](https://docs.gitlab.com/ee/user/project/pipelines/settings.html#git-shallow-clone))
+  - gitlab Runners: set `GIT_DEPTH` to `0` ([docs](https://docs.gitlab.com/ee/ci/pipelines/settings.html#limit-the-number-of-changes-fetched-during-clone))
   - bitbucket pipelines: set `clone: depth: full` ([docs](https://support.atlassian.com/bitbucket-cloud/docs/configure-bitbucket-pipelinesyml/))
 </details>
 


### PR DESCRIPTION
I noticed there was a broken link and the information was not up to date. I reference: https://github.com/timvink/mkdocs-git-revision-date-localized-plugin/blob/master/README.md?plain=1#L43.

* Set GIT_DEPTH=0
* Fix broken link