### PR TITLE
Add Co-author

### DIFF
--- a/src/mkdocs_git_authors_plugin/git/page.py
+++ b/src/mkdocs_git_authors_plugin/git/page.py
@@ -256,7 +256,7 @@ class Page(AbstractRepoObject):
                 # skip author as already available in Commit object
                 continue
 
-            result = re.search(r"Co-authored-by:(.*) <(.*)>", line)
+            result = re.search(r"Co-authored-by: (.*) <(.*)>", line)
             if result is not None and result.group(1) != "" and result.group(2) != "":
                 # Extract co-authors from the commit
                 co_author = self.repo().author(result.group(1), result.group(2))

--- a/src/mkdocs_git_authors_plugin/git/page.py
+++ b/src/mkdocs_git_authors_plugin/git/page.py
@@ -149,7 +149,7 @@ class Page(AbstractRepoObject):
             args.append("--ignore-revs-file")
             args.append(self.repo().config("ignore_commits"))
         args.append("--porcelain")
-        args.append("-w") # Ignore whitespace changes
+        args.append("-w")  # Ignore whitespace changes
         args.append(str(self._path))
         cmd = GitCommand("blame", args)
         cmd.run()
@@ -239,7 +239,7 @@ class Page(AbstractRepoObject):
         """
 
         args = []
-        args.append("-1") # Only existing sha
+        args.append("-1")  # Only existing sha
         args.append(sha)
         cmd = GitCommand("log", args)
         cmd.run()
@@ -260,7 +260,10 @@ class Page(AbstractRepoObject):
             if result is not None and result.group(1) != "" and result.group(2) != "":
                 # Extract co-authors from the commit
                 co_author = self.repo().author(result.group(1), result.group(2))
-                if co_author.email() not in ignore_authors and co_author.email() != commit.author().email():
+                if (
+                    co_author.email() not in ignore_authors
+                    and co_author.email() != commit.author().email()
+                ):
                     # Create the co-author
                     if co_author not in self._authors:
                         self._authors.append(co_author)

--- a/tests/basic_setup/docs/page_with_co_authors.md
+++ b/tests/basic_setup/docs/page_with_co_authors.md
@@ -1,7 +1,3 @@
-# Test with co-authors
+# Test with co-authors mentioned
 
 Page authors: {{ git_page_authors }}
-
-----
-
-Site authors: {{ git_site_authors }}

--- a/tests/basic_setup/docs/page_with_co_authors.md
+++ b/tests/basic_setup/docs/page_with_co_authors.md
@@ -1,0 +1,7 @@
+# Test with co-authors
+
+Page authors: {{ git_page_authors }}
+
+----
+
+Site authors: {{ git_site_authors }}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -154,7 +154,7 @@ def test_co_authors_working(tmp_path) -> None:
     contents = page_file.read_text()
     assert re.search("<span class='git-page-authors", contents)
     assert re.search(
-        "<a href='mailto:12074690\+fpozzobon@users.noreply.github.com'>Fabien Pozzobon</a>",
+        "fpozzobon@users.noreply.github.com'>Fabien Pozzobon</a>",
         contents,
     )
     assert re.search("<a href='mailto:jdoe@john.com'>John Doe</a>", contents)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -129,7 +129,7 @@ def setup_commit_history(testproject_path):
         repo.git.commit(message="homepage", author=author)
         repo.git.add("docs/page_with_co_authors.md")
         repo.git.commit(
-            message="co-authors commit\nCo-authored-by: Test Person <testtest@gmail.com>\nCo-authored-by: John Doe <jdoe@john.com>",
+            message="co-authors commit\nCo-authored-by: Test Person <testtest@gmail.com>\nCo-authored-by: Roger Doe <rdoe@john.com>",
             author=author,
         )
         os.chdir(str(cwd))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -42,8 +42,8 @@ DEFAULT_CONFIG = {
     "sort_authors_by": "name",
     "authorship_threshold_percent": 0,
     "strict": True,
-    #"sort_authors_by_name": True,
-    #"sort_reverse": False,
+    # "sort_authors_by_name": True,
+    # "sort_reverse": False,
 }
 
 #### Helpers ####
@@ -128,7 +128,10 @@ def setup_commit_history(testproject_path):
         repo.git.add("docs/page_with_tag.md")
         repo.git.commit(message="homepage", author=author)
         repo.git.add("docs/page_with_co_authors.md")
-        repo.git.commit(message="co-authors commit\nCo-authored-by: Test Person <testtest@gmail.com>\nCo-authored-by: John Doe <jdoe@john.com>", author=author)
+        repo.git.commit(
+            message="co-authors commit\nCo-authored-by: Test Person <testtest@gmail.com>\nCo-authored-by: John Doe <jdoe@john.com>",
+            author=author,
+        )
         os.chdir(str(cwd))
     except:
         os.chdir(str(cwd))
@@ -142,7 +145,7 @@ def commit_lines(r, file_name, author_name, author_email, num_of_lines=1):
     with open(file_name, "a") as the_file:
         for i in range(num_of_lines):
             the_file.write("Hello\n")
-    
+
     r.index.add([file_name])
     author = gitpython.Actor(author_name, author_email)
     r.index.commit("some commit", author=author)
@@ -514,17 +517,18 @@ def test_page_authors_summary(tmp_path):
 
     # Initial commit
     commit_lines(r, file_name, "Tim", "abc@abc.com")
-    
+
     repo_instance = repo.Repo()
     repo_instance.set_config(config)
     page_instance = repo_instance.page(file_name)
 
     authors_summary = util.page_authors_summary(page_instance, config)
 
-    assert authors_summary == "<span class='git-page-authors git-authors'>"\
-                            "<a href='mailto:abc@abc.com'>Tim</a>"\
-                            "</span>"
-
+    assert (
+        authors_summary == "<span class='git-page-authors git-authors'>"
+        "<a href='mailto:abc@abc.com'>Tim</a>"
+        "</span>"
+    )
 
     # Now add a line to the file
     # From a second author with same email
@@ -536,10 +540,11 @@ def test_page_authors_summary(tmp_path):
 
     authors_summary = util.page_authors_summary(page_instance, config)
 
-    assert authors_summary == "<span class='git-page-authors git-authors'>"\
-                            "<a href='mailto:abc@abc.com'>Tim</a>"\
-                            "</span>"
-
+    assert (
+        authors_summary == "<span class='git-page-authors git-authors'>"
+        "<a href='mailto:abc@abc.com'>Tim</a>"
+        "</span>"
+    )
 
     # Then a third commit from a new author
     commit_lines(r, file_name, "John", "john@abc.com")
@@ -550,10 +555,12 @@ def test_page_authors_summary(tmp_path):
 
     authors_summary = util.page_authors_summary(page_instance, config)
 
-    assert authors_summary == "<span class='git-page-authors git-authors'>"\
-                            "<a href='mailto:john@abc.com'>John</a>, "\
-                            "<a href='mailto:abc@abc.com'>Tim</a>"\
-                            "</span>"
+    assert (
+        authors_summary == "<span class='git-page-authors git-authors'>"
+        "<a href='mailto:john@abc.com'>John</a>, "
+        "<a href='mailto:abc@abc.com'>Tim</a>"
+        "</span>"
+    )
 
     os.chdir(cwd)
 
@@ -577,7 +584,7 @@ def test_page_authors_summary_showing_contribution(tmp_path):
 
     # Initial commit
     commit_lines(r, file_name, "Tim", "abc@abc.com")
-    
+
     repo_instance = repo.Repo()
     repo_instance.set_config(config)
     page_instance = repo_instance.page(file_name)
@@ -585,10 +592,11 @@ def test_page_authors_summary_showing_contribution(tmp_path):
     authors_summary = util.page_authors_summary(page_instance, config)
 
     # Contribution is not shown if there is only single Author
-    assert authors_summary == "<span class='git-page-authors git-authors'>"\
-                            "<a href='mailto:abc@abc.com'>Tim</a>"\
-                            "</span>"
-
+    assert (
+        authors_summary == "<span class='git-page-authors git-authors'>"
+        "<a href='mailto:abc@abc.com'>Tim</a>"
+        "</span>"
+    )
 
     # Now add a line to the file
     # From a second author with same email
@@ -601,10 +609,11 @@ def test_page_authors_summary_showing_contribution(tmp_path):
     authors_summary = util.page_authors_summary(page_instance, config)
 
     # Contribution is not shown if there is only single Author
-    assert authors_summary == "<span class='git-page-authors git-authors'>"\
-                            "<a href='mailto:abc@abc.com'>Tim</a>"\
-                            "</span>"
-
+    assert (
+        authors_summary == "<span class='git-page-authors git-authors'>"
+        "<a href='mailto:abc@abc.com'>Tim</a>"
+        "</span>"
+    )
 
     # Then a third commit from a new author
     commit_lines(r, file_name, "John", "john@abc.com")
@@ -616,15 +625,19 @@ def test_page_authors_summary_showing_contribution(tmp_path):
     authors_summary = util.page_authors_summary(page_instance, config)
 
     # Contribution is shown if there are multiple authors, ordered by contribution
-    assert authors_summary == "<span class='git-page-authors git-authors'>"\
-                            "<a href='mailto:abc@abc.com'>Tim</a> (66.67%), "\
-                            "<a href='mailto:john@abc.com'>John</a> (33.33%)"\
-                            "</span>"
+    assert (
+        authors_summary == "<span class='git-page-authors git-authors'>"
+        "<a href='mailto:abc@abc.com'>Tim</a> (66.67%), "
+        "<a href='mailto:john@abc.com'>John</a> (33.33%)"
+        "</span>"
+    )
 
     os.chdir(cwd)
 
 
-def test_page_authors_summary_showing_contribution_ordering_by_page_contribution(tmp_path):
+def test_page_authors_summary_showing_contribution_ordering_by_page_contribution(
+    tmp_path,
+):
     """
     Builds a fake git project with some commits.
 
@@ -650,7 +663,7 @@ def test_page_authors_summary_showing_contribution_ordering_by_page_contribution
     commit_lines(r, file_name2, "Tim", "tim@abc.com", 4)
     commit_lines(r, file_name2, "John", "john@abc.com", 16)
     commit_lines(r, file_name2, "Thomas", "thomas@abc.com", 8)
-    
+
     repo_instance = repo.Repo()
     repo_instance.set_config(config)
     page_instance = repo_instance.page(file_name)
@@ -659,19 +672,23 @@ def test_page_authors_summary_showing_contribution_ordering_by_page_contribution
     authors_summary = util.page_authors_summary(page_instance, config)
 
     # Contribution is shown if there are multiple authors, ordered by contribution on page
-    assert authors_summary == "<span class='git-page-authors git-authors'>"\
-                            "<a href='mailto:tim@abc.com'>Tim</a> (57.14%), "\
-                            "<a href='mailto:john@abc.com'>John</a> (28.57%), "\
-                            "<a href='mailto:thomas@abc.com'>Thomas</a> (14.29%)"\
-                            "</span>"
-    
+    assert (
+        authors_summary == "<span class='git-page-authors git-authors'>"
+        "<a href='mailto:tim@abc.com'>Tim</a> (57.14%), "
+        "<a href='mailto:john@abc.com'>John</a> (28.57%), "
+        "<a href='mailto:thomas@abc.com'>Thomas</a> (14.29%)"
+        "</span>"
+    )
+
     authors_summary = util.page_authors_summary(page_instance2, config)
 
-    assert authors_summary == "<span class='git-page-authors git-authors'>"\
-                            "<a href='mailto:john@abc.com'>John</a> (57.14%), "\
-                            "<a href='mailto:thomas@abc.com'>Thomas</a> (28.57%), "\
-                            "<a href='mailto:tim@abc.com'>Tim</a> (14.29%)"\
-                            "</span>"
+    assert (
+        authors_summary == "<span class='git-page-authors git-authors'>"
+        "<a href='mailto:john@abc.com'>John</a> (57.14%), "
+        "<a href='mailto:thomas@abc.com'>Thomas</a> (28.57%), "
+        "<a href='mailto:tim@abc.com'>Tim</a> (14.29%)"
+        "</span>"
+    )
 
     os.chdir(cwd)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -127,6 +127,8 @@ def setup_commit_history(testproject_path):
         repo.git.commit(message="homepage", author=author)
         repo.git.add("docs/page_with_tag.md")
         repo.git.commit(message="homepage", author=author)
+        repo.git.add("docs/page_with_co_authors.md")
+        repo.git.commit(message="co-authors commit\nCo-authored-by: Test Person <testtest@gmail.com>\nCo-authored-by: John Doe <jdoe@john.com>", author=author)
         os.chdir(str(cwd))
     except:
         os.chdir(str(cwd))


### PR DESCRIPTION
Adding co-author as described in [github](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors)

With this feature, co-author is now also extracted from commit message.

References: https://github.com/timvink/mkdocs-git-authors-plugin/issues/109